### PR TITLE
add course season management and add settings for students

### DIFF
--- a/frontend/src/lib/components/canvas/SemesterDivider.svelte
+++ b/frontend/src/lib/components/canvas/SemesterDivider.svelte
@@ -6,6 +6,7 @@
   } from "$lib/data/study-plan";
   import { useViewport } from "@xyflow/svelte";
   import { slotStatusMap } from "$lib/stores/progressStore.svelte";
+  import { courseStore } from "$lib/stores/courseStore.svelte";
 
   let {
     semester,
@@ -62,7 +63,7 @@
   font-weight="500"
   opacity={textOpacity}
 >
-  Semester {semester}
+  {courseStore.semesterLabel(semester)}
 </text>
 <text
   x="-100"

--- a/frontend/src/lib/components/header/TemplateSelector.svelte
+++ b/frontend/src/lib/components/header/TemplateSelector.svelte
@@ -7,6 +7,7 @@
     type StudyModel
   } from "$lib/data/courses";
   import { PROGRAMS, PROGRAM_PLANS } from "$lib/data/programs";
+  import { resolvePlan, planIntroYear, SEASON_LABELS, type Season } from "$lib/data/season";
   import Dropdown from "$lib/components/ui/Dropdown.svelte";
   import ConfirmationDialog from "$lib/components/ui/ConfirmationDialog.svelte";
 
@@ -15,177 +16,129 @@
     parttime: "Parttime",
   };
   const MODEL_ORDER: StudyModel[] = ["fulltime", "parttime"];
+  const SEASONS: Season[] = ["HS", "FS"];
 
   let showWarningDialog = $state(false);
   let pendingProgram = $state<string | null>(null);
   let pendingModel = $state<StudyModel | null>(null);
-  let pendingPlan = $state<string | null>(null);
+  let pendingYear = $state<number | null>(null);
+  let pendingSeason = $state<Season | null>(null);
 
-  const hasPendingChanges = $derived.by(() => {
-    const targetProgram = pendingProgram ?? courseStore.currentTemplate.studiengang;
-    const targetModel = pendingModel ?? courseStore.currentTemplate.modell;
-    const targetPlan = pendingPlan ?? courseStore.selectedPlan;
+  const program = $derived(pendingProgram ?? courseStore.currentTemplate.studiengang);
+  const model = $derived(pendingModel ?? courseStore.currentTemplate.modell);
+  const year = $derived(pendingYear ?? courseStore.startYear);
+  const season = $derived(pendingSeason ?? courseStore.startSeason);
 
-    return (
-      targetProgram !== courseStore.currentTemplate.studiengang ||
-      targetModel !== courseStore.currentTemplate.modell ||
-      targetPlan !== courseStore.selectedPlan
-    );
-  });
+  const hasPendingChanges = $derived(
+    program !== courseStore.currentTemplate.studiengang ||
+    model !== courseStore.currentTemplate.modell ||
+    year !== courseStore.startYear ||
+    season !== courseStore.startSeason
+  );
 
   const isPlanCustomized = $derived.by(() => courseStore.isStudyPlanCustomized());
-  const targetTemplate = $derived.by(() => resolveTargetTemplate());
 
-  const canLoadTemplate = $derived.by(() => {
-    if (!targetTemplate) return false;
-    return hasPendingChanges || isPlanCustomized;
+  const targetTemplate = $derived.by(() => {
+    const plan = resolvePlan(getAvailablePlans(program, model), { year, season });
+    if (!plan) return undefined;
+    return getTemplatesByProgram(program, model).find((template) => template.plan === plan);
   });
 
+  const templateChanges = $derived(
+    !!targetTemplate && targetTemplate.id !== courseStore.currentTemplate.id
+  );
+  const canLoad = $derived(!!targetTemplate && (hasPendingChanges || isPlanCustomized));
+
   const programOptions = $derived.by(() =>
-    PROGRAMS.map((program) => {
-      const availablePlanCount = (PROGRAM_PLANS[program.shortName] ?? []).length;
+    PROGRAMS.map((entry) => {
+      const planCount = (PROGRAM_PLANS[entry.shortName] ?? []).length;
       return {
-        value: program.shortName,
-        label: program.name,
-        disabled: availablePlanCount === 0,
-        tooltip: availablePlanCount === 0 ? "Coming soon" : undefined,
+        value: entry.shortName,
+        label: entry.name,
+        disabled: planCount === 0,
+        tooltip: planCount === 0 ? "Coming soon" : undefined,
       };
     })
   );
 
   const modelOptions = $derived.by(() => {
-    const program = pendingProgram ?? courseStore.currentTemplate.studiengang;
     const availableModels = getAvailableModels(program);
     const candidates: string[] = [...MODEL_ORDER];
-
-    availableModels.forEach((model) => {
-      if (!candidates.includes(model)) {
-        candidates.push(model);
-      }
+    availableModels.forEach((entry) => {
+      if (!candidates.includes(entry)) candidates.push(entry);
     });
-
     return candidates.map((value) => {
       const isAvailable = availableModels.includes(value as StudyModel);
-      const label = MODEL_LABELS[value as keyof typeof MODEL_LABELS] ?? value;
       return {
         value,
-        label,
+        label: MODEL_LABELS[value as keyof typeof MODEL_LABELS] ?? value,
         disabled: !isAvailable,
         tooltip: !isAvailable ? "Coming soon" : undefined,
       };
     });
   });
 
-  const planOptions = $derived.by(() => {
-    const program = pendingProgram ?? courseStore.currentTemplate.studiengang;
-    const model = pendingModel ?? courseStore.currentTemplate.modell;
-    const actualPlans = model ? getAvailablePlans(program, model) : [];
-    const declaredPlans = PROGRAM_PLANS[program] ?? [];
-    const currentSelection = pendingPlan ?? courseStore.selectedPlan;
-    const combined: string[] = [...actualPlans];
-
-    declaredPlans.forEach((plan) => {
-      if (!combined.includes(plan)) {
-        combined.push(plan);
-      }
-    });
-
-    if (currentSelection && !combined.includes(currentSelection)) {
-      combined.push(currentSelection);
-    }
-
-    return [...combined]
-      .sort()
-      .map((plan) => ({
-        value: plan,
-        label: plan,
-        disabled: !actualPlans.includes(plan),
-        tooltip: !actualPlans.includes(plan) ? "Coming soon" : undefined,
-      }));
+  const yearOptions = $derived.by(() => {
+    const introYears = getAvailablePlans(program, model)
+      .map(planIntroYear)
+      .filter((value): value is number => value !== null);
+    const currentYear = new Date().getFullYear();
+    const earliest = introYears.length ? Math.min(...introYears) : currentYear;
+    const latest = Math.max(currentYear + 1, ...introYears);
+    const years: number[] = [];
+    for (let value = latest; value >= earliest; value--) years.push(value);
+    return years.map((value) => ({ value: String(value), label: String(value) }));
   });
 
-  function syncPendingPlan(program: string, model: StudyModel | null) {
-    if (!model) {
-      pendingPlan = null;
-      return;
-    }
-
-    const plans = getAvailablePlans(program, model);
-    if (!plans.length) {
-      pendingPlan = null;
-      return;
-    }
-
-    const current = pendingPlan ?? courseStore.selectedPlan;
-    pendingPlan = plans.includes(current) ? current : plans[0];
-  }
-
-  function clearPendingSelections() {
-    pendingProgram = null;
-    pendingModel = null;
-    pendingPlan = null;
-  }
+  const seasonOptions = SEASONS.map((value) => ({ value, label: SEASON_LABELS[value] }));
 
   function handleProgramChange(value: string) {
     pendingProgram = value;
     const models = getAvailableModels(value);
-    if (!models.length) {
-      pendingModel = null;
-      pendingPlan = null;
-      return;
-    }
-
-    const currentModel = pendingModel ?? courseStore.currentTemplate.modell;
-    pendingModel = models.includes(currentModel) ? currentModel : models[0];
-    syncPendingPlan(value, pendingModel);
+    const current = pendingModel ?? courseStore.currentTemplate.modell;
+    pendingModel = models.length ? (models.includes(current) ? current : models[0]) : null;
   }
 
   function handleModelChange(value: string) {
-    const program = pendingProgram ?? courseStore.currentTemplate.studiengang;
     pendingModel = value as StudyModel;
-    syncPendingPlan(program, pendingModel);
   }
 
-  function handlePlanChange(value: string) {
-    pendingPlan = value;
+  function handleYearChange(value: string) {
+    pendingYear = Number(value);
   }
 
-  function resolveTargetTemplate() {
-    const program = pendingProgram ?? courseStore.currentTemplate.studiengang;
-    const model = pendingModel ?? courseStore.currentTemplate.modell;
-    const candidates = getAvailablePlans(program, model);
-    const desiredPlan = pendingPlan ?? courseStore.selectedPlan;
-    const plan = candidates.includes(desiredPlan) ? desiredPlan : candidates[0];
-    if (!plan) return undefined;
+  function handleSeasonChange(value: string) {
+    pendingSeason = value as Season;
+  }
 
-    return getTemplatesByProgram(program, model).find((template) => template.plan === plan);
+  function clearPending() {
+    pendingProgram = null;
+    pendingModel = null;
+    pendingYear = null;
+    pendingSeason = null;
   }
 
   function handleLoadClick() {
-    if (!targetTemplate) {
-      return;
-    }
-
-    if (!hasPendingChanges && !isPlanCustomized) {
-      return;
-    }
-
-    if (isPlanCustomized) {
+    if (!canLoad || !targetTemplate) return;
+    // Reset the study plan when loading a different curriculum, or when
+    // reloading the current one to discard customizations.
+    const reset = templateChanges || !hasPendingChanges;
+    if (isPlanCustomized && reset) {
       showWarningDialog = true;
       return;
     }
+    applyStart(reset);
+  }
 
-    courseStore.switchTemplate(targetTemplate.id, true);
-    clearPendingSelections();
+  function applyStart(reset: boolean) {
+    if (!targetTemplate) return;
+    courseStore.applyStart(targetTemplate.id, year, season, reset);
+    clearPending();
   }
 
   function confirmTemplateSwitch() {
-    const targetTemplate = resolveTargetTemplate();
-    if (!targetTemplate) return;
-
-    courseStore.switchTemplate(targetTemplate.id, true);
+    applyStart(true);
     showWarningDialog = false;
-    clearPendingSelections();
   }
 
   function cancelTemplateSwitch() {
@@ -200,7 +153,7 @@
     >
     <Dropdown
       options={programOptions}
-      selected={pendingProgram ?? courseStore.currentTemplate.studiengang}
+      selected={program}
       onSelect={handleProgramChange}
       minWidth="100%"
     />
@@ -212,28 +165,41 @@
     >
     <Dropdown
       options={modelOptions}
-      selected={pendingModel ?? courseStore.currentTemplate.modell}
+      selected={model}
       onSelect={handleModelChange}
       minWidth="100%"
     />
   </div>
 
-  <div class="space-y-1.5">
-    <label for="plan-select" class="text-xs font-medium text-text-secondary"
-      >Plan</label
-    >
-    <Dropdown
-      options={planOptions}
-      selected={pendingPlan ?? courseStore.selectedPlan}
-      onSelect={handlePlanChange}
-      minWidth="100%"
-    />
+  <div class="grid grid-cols-2 gap-2">
+    <div class="space-y-1.5">
+      <label for="start-year-select" class="text-xs font-medium text-text-secondary"
+        >Start Year</label
+      >
+      <Dropdown
+        options={yearOptions}
+        selected={String(year)}
+        onSelect={handleYearChange}
+        minWidth="100%"
+      />
+    </div>
+    <div class="space-y-1.5">
+      <label for="start-season-select" class="text-xs font-medium text-text-secondary"
+        >Start Season</label
+      >
+      <Dropdown
+        options={seasonOptions}
+        selected={season}
+        onSelect={handleSeasonChange}
+        minWidth="100%"
+      />
+    </div>
   </div>
 
   <button
     onclick={handleLoadClick}
-    disabled={!canLoadTemplate}
-    class="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg font-medium text-sm transition-colors {canLoadTemplate
+    disabled={!canLoad}
+    class="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg font-medium text-sm transition-colors {canLoad
       ? 'bg-blue-600 text-white hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600'
       : 'bg-gray-200 text-gray-500 cursor-not-allowed dark:bg-gray-800 dark:text-gray-500'}"
   >

--- a/frontend/src/lib/components/sidebar/CourseDetailsPanel.svelte
+++ b/frontend/src/lib/components/sidebar/CourseDetailsPanel.svelte
@@ -7,6 +7,7 @@
   } from '$lib/stores/uiStore.svelte';
   import { courseStore } from '$lib/stores/courseStore.svelte';
   import { getCourseById } from '$lib/data/courses';
+  import { SEASON_LABELS, type Season } from '$lib/data/season';
   import ElectiveCourseSelector from './ElectiveCourseSelector.svelte';
   import PrerequisiteList from './PrerequisiteList.svelte';
   import ActionButtons from './ActionButtons.svelte';
@@ -62,6 +63,16 @@
 
   const prerequisiteNote = $derived.by(() => displayCourse?.prerequisiteNote?.trim() ?? '');
   const isDrawerOpen = $derived(hasSelection());
+
+  const seasonInfo = $derived.by(() => {
+    const seasons = displayCourse?.seasons;
+    if (!seasons || seasons.length === 0) return null;
+    const ordered = (['HS', 'FS'] as Season[]).filter((season) => seasons.includes(season));
+    return {
+      short: ordered.join(' + '),
+      full: ordered.map((season) => SEASON_LABELS[season]).join(' & ')
+    };
+  });
 </script>
 
 <!-- mobile backdrop -->
@@ -101,6 +112,12 @@
             <div class="i-lucide-calendar text-text-secondary"></div>
             <span>Semester {activePlanNode?.semester ?? '?'}</span>
           </div>
+          {#if seasonInfo}
+            <div class="flex items-center gap-1.5" title="Offered in {seasonInfo.full}">
+              <div class="i-lucide-sun text-text-secondary"></div>
+              <span>{seasonInfo.short}</span>
+            </div>
+          {/if}
         </div>
         
         {#if displayCourse?.type}

--- a/frontend/src/lib/components/sidebar/ElectiveCourseSelector.svelte
+++ b/frontend/src/lib/components/sidebar/ElectiveCourseSelector.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { courseStore } from '$lib/stores/courseStore.svelte';
-  import { COURSES, getCourseById } from '$lib/data/courses';
+  import { COURSES, getCourseById, type Course } from '$lib/data/courses';
+  import { SEASON_LABELS, type Season } from '$lib/data/season';
   import PrerequisiteList from '$lib/components/sidebar/PrerequisiteList.svelte';
   import ActionButtons from '$lib/components/sidebar/ActionButtons.svelte';
   import Combobox from '$lib/components/ui/Combobox.svelte';
@@ -46,13 +47,32 @@
     })
   );
 
-  const comboboxOptions = $derived(
-    availableCourses.map(course => ({
-      value: course.id,
-      label: `${course.label} (${course.id}) — ${course.ects} ECTS`,
-      keywords: [course.label, course.id]
-    }))
-  );
+  const slotSeason = $derived(slotNode ? courseStore.seasonOf(slotNode.semester) : null);
+
+  function isOfferedIn(course: Course, season: Season): boolean {
+    return !course.seasons || course.seasons.length === 0 || course.seasons.includes(season);
+  }
+
+  const comboboxOptions = $derived.by(() => {
+    const options = availableCourses.map(course => {
+      const outOfSeason = slotSeason !== null && !isOfferedIn(course, slotSeason);
+      return {
+        value: course.id,
+        label: `${course.label} (${course.id}) — ${course.ects} ECTS`,
+        keywords: [course.label, course.id],
+        // keep an already-chosen course usable even if the start season later changed
+        disabled: outOfSeason && course.id !== selectedCourseId,
+        tooltip: outOfSeason ? `Only offered in ${formatSeasons(course.seasons)}` : undefined
+      };
+    });
+    // out-of-season (disabled) courses sink to the bottom; order is otherwise stable
+    return options.sort((a, b) => Number(a.disabled) - Number(b.disabled));
+  });
+
+  function formatSeasons(seasons: Season[] | undefined): string {
+    if (!seasons || seasons.length === 0) return 'other semesters';
+    return (['HS', 'FS'] as Season[]).filter(s => seasons.includes(s)).map(s => SEASON_LABELS[s]).join(' & ');
+  }
 
   function handleCourseSelect(courseId: string) {
     if (courseId) {

--- a/frontend/src/lib/components/sidebar/SettingsSidebar.svelte
+++ b/frontend/src/lib/components/sidebar/SettingsSidebar.svelte
@@ -150,6 +150,35 @@
 
         <div class="border-b border-border-primary"></div>
 
+        <!-- Study Start -->
+        <div>
+          <div class="text-base font-bold text-text-primary mb-1">Study Start</div>
+          <p class="text-sm text-text-secondary mb-4">Sets which semesters run in autumn vs spring.</p>
+          <div class="flex items-center justify-between">
+            <span class="text-base text-text-primary">Started semester</span>
+            <div class="flex rounded-lg border border-border-primary overflow-hidden text-sm" role="group" aria-label="Started semester">
+              <button
+                onclick={() => courseStore.setStartSeason('HS')}
+                class="px-3 py-1.5 transition-colors {courseStore.startSeason === 'HS'
+                  ? 'bg-blue-600 dark:bg-blue-500 text-white'
+                  : 'text-text-primary hover:bg-bg-secondary'}"
+              >
+                Herbst
+              </button>
+              <button
+                onclick={() => courseStore.setStartSeason('FS')}
+                class="px-3 py-1.5 transition-colors {courseStore.startSeason === 'FS'
+                  ? 'bg-blue-600 dark:bg-blue-500 text-white'
+                  : 'text-text-primary hover:bg-bg-secondary'}"
+              >
+                Frühling
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div class="border-b border-border-primary"></div>
+
         <!-- Data Management -->
         <div>
           <div class="text-base font-bold text-text-primary mb-4">Data Management</div>

--- a/frontend/src/lib/components/sidebar/SettingsSidebar.svelte
+++ b/frontend/src/lib/components/sidebar/SettingsSidebar.svelte
@@ -150,35 +150,6 @@
 
         <div class="border-b border-border-primary"></div>
 
-        <!-- Study Start -->
-        <div>
-          <div class="text-base font-bold text-text-primary mb-1">Study Start</div>
-          <p class="text-sm text-text-secondary mb-4">Sets which semesters run in autumn vs spring.</p>
-          <div class="flex items-center justify-between">
-            <span class="text-base text-text-primary">Started semester</span>
-            <div class="flex rounded-lg border border-border-primary overflow-hidden text-sm" role="group" aria-label="Started semester">
-              <button
-                onclick={() => courseStore.setStartSeason('HS')}
-                class="px-3 py-1.5 transition-colors {courseStore.startSeason === 'HS'
-                  ? 'bg-blue-600 dark:bg-blue-500 text-white'
-                  : 'text-text-primary hover:bg-bg-secondary'}"
-              >
-                Herbst
-              </button>
-              <button
-                onclick={() => courseStore.setStartSeason('FS')}
-                class="px-3 py-1.5 transition-colors {courseStore.startSeason === 'FS'
-                  ? 'bg-blue-600 dark:bg-blue-500 text-white'
-                  : 'text-text-primary hover:bg-bg-secondary'}"
-              >
-                Frühling
-              </button>
-            </div>
-          </div>
-        </div>
-
-        <div class="border-b border-border-primary"></div>
-
         <!-- Data Management -->
         <div>
           <div class="text-base font-bold text-text-primary mb-4">Data Management</div>

--- a/frontend/src/lib/components/ui/Combobox.svelte
+++ b/frontend/src/lib/components/ui/Combobox.svelte
@@ -252,6 +252,7 @@
           <li
             role="option"
             aria-selected={option.value === selected}
+            title={option.tooltip}
             onclick={() => selectOption(option)}
             onkeydown={(e) => e.key === "Enter" && selectOption(option)}
             tabindex="-1"

--- a/frontend/src/lib/data/course-data-adapter.ts
+++ b/frontend/src/lib/data/course-data-adapter.ts
@@ -1,4 +1,5 @@
 import type { Course, ModuleType, PrerequisiteLink, PrerequisiteRule } from './courses';
+import type { Season } from './season';
 
 type RawPrerequisiteLink = 'und' | 'oder' | 'UND' | 'ODER' | 'AND' | 'OR';
 
@@ -86,12 +87,33 @@ const orderedModuleEntries = Object.entries(moduleFileGlob)
   .sort((a, b) => compareSemester(a.semester, b.semester));
 
 const moduleIndex: Map<string, RawModule> = new Map();
+// Seasons must be unioned across every semester file: a module's latest entry
+// only carries that one file's offers, so both-season modules look single-season.
+const seasonsByShortName: Map<string, Set<Season>> = new Map();
 
 for (const entry of orderedModuleEntries) {
   entry.file.data.forEach((module) => {
     if (!module.ShortName) return;
     moduleIndex.set(module.ShortName, module);
+
+    const seasons = seasonsByShortName.get(module.ShortName) ?? new Set<Season>();
+    for (const season of offeredSeasons(module)) seasons.add(season);
+    seasonsByShortName.set(module.ShortName, seasons);
   });
+}
+
+// Seasons a module is offered in, preferring Informatik offers like selectModuleType.
+function offeredSeasons(module: RawModule): Season[] {
+  const offers = module.ModuleOffers ?? [];
+  const informatikOffers = offers.filter((offer) => offer.DegreeProgramme === 'Informatik');
+  const candidateOffers = informatikOffers.length > 0 ? informatikOffers : offers;
+
+  const seasons: Season[] = [];
+  for (const offer of candidateOffers) {
+    if (offer.CourseOffering === 'Frühling') seasons.push('FS');
+    else if (offer.CourseOffering === 'Herbst') seasons.push('HS');
+  }
+  return seasons;
 }
 
 function mapModuleType(rawType: string | undefined): ModuleType | undefined {
@@ -170,7 +192,8 @@ function toCourse(module: RawModule, plan: string): Course {
     prerequisites: mapPrerequisites(module.Prerequisites ?? []),
     prerequisiteNote: module.PrerequisiteNote || undefined,
     assessmentLevelPassed: module.AssessmentLevelPassed ?? undefined,
-    type: selectModuleType(module, plan)
+    type: selectModuleType(module, plan),
+    seasons: Array.from(seasonsByShortName.get(module.ShortName) ?? [])
   };
 }
 

--- a/frontend/src/lib/data/courses.ts
+++ b/frontend/src/lib/data/courses.ts
@@ -1,5 +1,6 @@
 import { loadCourseData } from './course-data-adapter';
 import studyProgrammes from './hslu_data/study_programmes.json';
+import type { Season } from './season';
 
 export type Status = "locked" | "available" | "completed";
 
@@ -23,6 +24,8 @@ export type Course = {
   prerequisiteNote?: string;
   assessmentLevelPassed?: boolean;
   type?: ModuleType;
+  // Seasons the module is offered in; empty/undefined means unknown (treated as any).
+  seasons?: Season[];
 };
 
 export type TemplateSlot = {

--- a/frontend/src/lib/data/season.ts
+++ b/frontend/src/lib/data/season.ts
@@ -1,0 +1,15 @@
+export type Season = 'HS' | 'FS';
+
+export const SEASON_LABELS: Record<Season, string> = {
+  HS: 'Herbst (HS)',
+  FS: 'Frühling (FS)'
+};
+
+export function otherSeason(season: Season): Season {
+  return season === 'HS' ? 'FS' : 'HS';
+}
+
+// Semester 1 runs in the start season; every later semester alternates.
+export function seasonOfSemester(semester: number, startSeason: Season): Season {
+  return (semester - 1) % 2 === 0 ? startSeason : otherSeason(startSeason);
+}

--- a/frontend/src/lib/data/season.ts
+++ b/frontend/src/lib/data/season.ts
@@ -13,3 +13,40 @@ export function otherSeason(season: Season): Season {
 export function seasonOfSemester(semester: number, startSeason: Season): Season {
   return (semester - 1) % 2 === 0 ? startSeason : otherSeason(startSeason);
 }
+
+export type Term = { season: Season; year: number };
+
+// Orders terms chronologically: spring sorts before autumn within a year.
+export function termOrdinal(year: number, season: Season): number {
+  return year * 2 + (season === 'HS' ? 1 : 0);
+}
+
+export function formatTerm(term: Term): string {
+  return `${term.season} ${term.year}`;
+}
+
+// The calendar term a 1-indexed plan semester falls in, given the start term.
+export function termOfSemester(semester: number, start: Term): Term {
+  const ordinal = termOrdinal(start.year, start.season) + (semester - 1);
+  return { year: Math.floor(ordinal / 2), season: ordinal % 2 === 1 ? 'HS' : 'FS' };
+}
+
+// Plan codes are introduced each autumn, e.g. "HS25" -> autumn 2025.
+export function planIntroYear(plan: string): number | null {
+  const match = /^HS(\d{2})$/.exec(plan);
+  return match ? 2000 + Number(match[1]) : null;
+}
+
+// The plan in effect for a start term: the latest one introduced on or before
+// it, falling back to the earliest available plan.
+export function resolvePlan(availablePlans: string[], start: Term): string | null {
+  const startOrdinal = termOrdinal(start.year, start.season);
+  const dated = availablePlans
+    .map((plan) => ({ plan, year: planIntroYear(plan) }))
+    .filter((entry): entry is { plan: string; year: number } => entry.year !== null)
+    .sort((a, b) => a.year - b.year);
+  if (dated.length === 0) return null;
+
+  const eligible = dated.filter((entry) => termOrdinal(entry.year, 'HS') <= startOrdinal);
+  return (eligible.at(-1) ?? dated[0]).plan;
+}

--- a/frontend/src/lib/data/season.ts
+++ b/frontend/src/lib/data/season.ts
@@ -25,6 +25,12 @@ export function formatTerm(term: Term): string {
   return `${term.season} ${term.year}`;
 }
 
+// Default start term for a brand-new user: autumn (the standard intake) of the
+// current year.
+export function currentStartTerm(now: Date = new Date()): Term {
+  return { year: now.getFullYear(), season: 'HS' };
+}
+
 // The calendar term a 1-indexed plan semester falls in, given the start term.
 export function termOfSemester(semester: number, start: Term): Term {
   const ordinal = termOrdinal(start.year, start.season) + (semester - 1);

--- a/frontend/src/lib/stores/courseStore.svelte.ts
+++ b/frontend/src/lib/stores/courseStore.svelte.ts
@@ -27,7 +27,7 @@ import { progressStore, slotStatusMap } from './progressStore.svelte';
 import { loadPlan, savePlan, loadLegacySelections, planPrefs } from './planStorage';
 import { DragController } from './dragController.svelte';
 import { canSelectCourse, isPlanCustomized } from '$lib/data/plan-rules';
-import { seasonOfSemester, type Season } from '$lib/data/season';
+import { seasonOfSemester, termOfSemester, formatTerm, planIntroYear, type Season } from '$lib/data/season';
 
 type FlowNodePosition = { x: number; y: number };
 type SemesterIndicator = { semester: number; isPreview: boolean; length: number };
@@ -41,6 +41,7 @@ class CourseStore {
   studyPlan = $state<StudyPlan>(createStudyPlan(AVAILABLE_TEMPLATES[0], {}));
   showShortNamesOnly = $state(false);
   startSeason = $state<Season>('HS');
+  startYear = $state<number>(planIntroYear(AVAILABLE_TEMPLATES[0].plan) ?? new Date().getFullYear());
 
   private graph = $derived.by(() => toGraph(this.studyPlan, this.showShortNamesOnly));
   private positionedNodes = $derived.by(() => layoutNodes(this.graph.nodes, this.studyPlan.rows));
@@ -124,20 +125,32 @@ class CourseStore {
     planPrefs.saveStartSeason(season);
   }
 
+  // Switch to `templateId` and record the start term that derived it. When only
+  // the start term changes within the same plan, the curriculum is left intact.
+  applyStart(templateId: string, year: number, season: Season, forceReset = false) {
+    this.startYear = year;
+    this.startSeason = season;
+    planPrefs.saveStartYear(year);
+    planPrefs.saveStartSeason(season);
+    if (forceReset || templateId !== this.currentTemplate.id) {
+      this.switchTemplate(templateId, forceReset);
+    }
+  }
+
   // The calendar season (HS/FS) a given 1-indexed plan semester falls in.
   seasonOf(semester: number): Season {
     return seasonOfSemester(semester, this.startSeason);
+  }
+
+  // The calendar term label (e.g. "FS 2026") for a 1-indexed plan semester.
+  semesterLabel(semester: number): string {
+    return formatTerm(termOfSemester(semester, { year: this.startYear, season: this.startSeason }));
   }
 
   init() {
     const savedShortNames = planPrefs.loadShortNames();
     if (savedShortNames !== null) {
       this.showShortNamesOnly = savedShortNames;
-    }
-
-    const savedStartSeason = planPrefs.loadStartSeason();
-    if (savedStartSeason !== null) {
-      this.startSeason = savedStartSeason;
     }
 
     const savedTemplateId = planPrefs.loadTemplateId();
@@ -153,6 +166,9 @@ class CourseStore {
         this.currentTemplate = matchingTemplate;
       }
     }
+
+    this.startSeason = planPrefs.loadStartSeason() ?? 'HS';
+    this.startYear = planPrefs.loadStartYear() ?? planIntroYear(this.currentTemplate.plan) ?? this.startYear;
 
     setCoursePlan(this.currentTemplate.plan);
 

--- a/frontend/src/lib/stores/courseStore.svelte.ts
+++ b/frontend/src/lib/stores/courseStore.svelte.ts
@@ -2,6 +2,7 @@ import {
   AVAILABLE_TEMPLATES,
   getTemplateById,
   getTemplatesByProgram,
+  getAvailablePlans,
   setCoursePlan
 } from '$lib/data/courses';
 import {
@@ -27,7 +28,17 @@ import { progressStore, slotStatusMap } from './progressStore.svelte';
 import { loadPlan, savePlan, loadLegacySelections, planPrefs } from './planStorage';
 import { DragController } from './dragController.svelte';
 import { canSelectCourse, isPlanCustomized } from '$lib/data/plan-rules';
-import { seasonOfSemester, termOfSemester, formatTerm, planIntroYear, type Season } from '$lib/data/season';
+import {
+  seasonOfSemester,
+  termOfSemester,
+  formatTerm,
+  planIntroYear,
+  resolvePlan,
+  currentStartTerm,
+  type Season
+} from '$lib/data/season';
+
+const INITIAL_TERM = currentStartTerm();
 
 type FlowNodePosition = { x: number; y: number };
 type SemesterIndicator = { semester: number; isPreview: boolean; length: number };
@@ -40,8 +51,8 @@ class CourseStore {
   currentTemplate = $state(AVAILABLE_TEMPLATES[0]);
   studyPlan = $state<StudyPlan>(createStudyPlan(AVAILABLE_TEMPLATES[0], {}));
   showShortNamesOnly = $state(false);
-  startSeason = $state<Season>('HS');
-  startYear = $state<number>(planIntroYear(AVAILABLE_TEMPLATES[0].plan) ?? new Date().getFullYear());
+  startSeason = $state<Season>(INITIAL_TERM.season);
+  startYear = $state<number>(INITIAL_TERM.year);
 
   private graph = $derived.by(() => toGraph(this.studyPlan, this.showShortNamesOnly));
   private positionedNodes = $derived.by(() => layoutNodes(this.graph.nodes, this.studyPlan.rows));
@@ -149,20 +160,33 @@ class CourseStore {
 
     const savedTemplateId = planPrefs.loadTemplateId();
     const savedPlanCode = planPrefs.loadPlanCode();
+    const savedTemplate = savedTemplateId
+      ? getTemplateById(savedTemplateId)
+      : savedPlanCode
+        ? getTemplatesByProgram(this.currentTemplate.studiengang, this.currentTemplate.modell)
+            .find((t) => t.plan === savedPlanCode)
+        : undefined;
 
-    const savedTemplate = savedTemplateId ? getTemplateById(savedTemplateId) : undefined;
     if (savedTemplate) {
+      // returning user: keep their curriculum and start term
       this.currentTemplate = savedTemplate;
-    } else if (savedPlanCode) {
-      const matchingTemplate = getTemplatesByProgram(this.currentTemplate.studiengang, this.currentTemplate.modell)
-        .find((t) => t.plan === savedPlanCode);
-      if (matchingTemplate) {
-        this.currentTemplate = matchingTemplate;
-      }
+      this.startSeason = planPrefs.loadStartSeason() ?? 'HS';
+      this.startYear = planPrefs.loadStartYear() ?? planIntroYear(savedTemplate.plan) ?? this.startYear;
+    } else {
+      // new user: default to the current calendar term and derive the curriculum
+      const term = currentStartTerm();
+      this.startSeason = term.season;
+      this.startYear = term.year;
+      const plan = resolvePlan(
+        getAvailablePlans(this.currentTemplate.studiengang, this.currentTemplate.modell),
+        term
+      );
+      const template = plan
+        ? getTemplatesByProgram(this.currentTemplate.studiengang, this.currentTemplate.modell)
+            .find((t) => t.plan === plan)
+        : undefined;
+      if (template) this.currentTemplate = template;
     }
-
-    this.startSeason = planPrefs.loadStartSeason() ?? 'HS';
-    this.startYear = planPrefs.loadStartYear() ?? planIntroYear(this.currentTemplate.plan) ?? this.startYear;
 
     setCoursePlan(this.currentTemplate.plan);
 

--- a/frontend/src/lib/stores/courseStore.svelte.ts
+++ b/frontend/src/lib/stores/courseStore.svelte.ts
@@ -63,7 +63,6 @@ class CourseStore {
       .filter((plan, index, arr) => arr.indexOf(plan) === index)
       .sort()
   );
-  selectedPlan = $derived(this.currentTemplate.plan);
   nodes = $derived.by(() => this.drag.activeNodes);
   edges = $derived.by(() => orderEdgeHandles(this.graph.edges, this.positionedNodes));
 
@@ -118,11 +117,6 @@ class CourseStore {
     this.showShortNamesOnly = !this.showShortNamesOnly;
     this.drag.clear();
     planPrefs.saveShortNames(this.showShortNamesOnly);
-  }
-
-  setStartSeason(season: Season) {
-    this.startSeason = season;
-    planPrefs.saveStartSeason(season);
   }
 
   // Switch to `templateId` and record the start term that derived it. When only

--- a/frontend/src/lib/stores/courseStore.svelte.ts
+++ b/frontend/src/lib/stores/courseStore.svelte.ts
@@ -27,6 +27,7 @@ import { progressStore, slotStatusMap } from './progressStore.svelte';
 import { loadPlan, savePlan, loadLegacySelections, planPrefs } from './planStorage';
 import { DragController } from './dragController.svelte';
 import { canSelectCourse, isPlanCustomized } from '$lib/data/plan-rules';
+import { seasonOfSemester, type Season } from '$lib/data/season';
 
 type FlowNodePosition = { x: number; y: number };
 type SemesterIndicator = { semester: number; isPreview: boolean; length: number };
@@ -39,6 +40,7 @@ class CourseStore {
   currentTemplate = $state(AVAILABLE_TEMPLATES[0]);
   studyPlan = $state<StudyPlan>(createStudyPlan(AVAILABLE_TEMPLATES[0], {}));
   showShortNamesOnly = $state(false);
+  startSeason = $state<Season>('HS');
 
   private graph = $derived.by(() => toGraph(this.studyPlan, this.showShortNamesOnly));
   private positionedNodes = $derived.by(() => layoutNodes(this.graph.nodes, this.studyPlan.rows));
@@ -117,10 +119,25 @@ class CourseStore {
     planPrefs.saveShortNames(this.showShortNamesOnly);
   }
 
+  setStartSeason(season: Season) {
+    this.startSeason = season;
+    planPrefs.saveStartSeason(season);
+  }
+
+  // The calendar season (HS/FS) a given 1-indexed plan semester falls in.
+  seasonOf(semester: number): Season {
+    return seasonOfSemester(semester, this.startSeason);
+  }
+
   init() {
     const savedShortNames = planPrefs.loadShortNames();
     if (savedShortNames !== null) {
       this.showShortNamesOnly = savedShortNames;
+    }
+
+    const savedStartSeason = planPrefs.loadStartSeason();
+    if (savedStartSeason !== null) {
+      this.startSeason = savedStartSeason;
     }
 
     const savedTemplateId = planPrefs.loadTemplateId();

--- a/frontend/src/lib/stores/planStorage.ts
+++ b/frontend/src/lib/stores/planStorage.ts
@@ -8,6 +8,7 @@ const KEYS = {
   plan: 'selectedPlan',
   shortNames: 'showShortNamesOnly',
   startSeason: 'startSeason',
+  startYear: 'startYear',
   legacySelections: 'userSelections',
   planFor: (templateId: string) => `studyPlan:${templateId}`
 } as const;
@@ -82,6 +83,14 @@ export const planPrefs = {
   loadStartSeason(): Season | null {
     const raw = read(KEYS.startSeason);
     return raw === 'HS' || raw === 'FS' ? raw : null;
+  },
+  saveStartYear(year: number): void {
+    write(KEYS.startYear, String(year));
+  },
+  loadStartYear(): number | null {
+    const raw = read(KEYS.startYear);
+    const year = raw ? Number(raw) : NaN;
+    return Number.isInteger(year) ? year : null;
   },
   saveShortNames(value: boolean): void {
     write(KEYS.shortNames, JSON.stringify(value));

--- a/frontend/src/lib/stores/planStorage.ts
+++ b/frontend/src/lib/stores/planStorage.ts
@@ -1,11 +1,13 @@
 import { browser } from '$app/environment';
 import type { CurriculumTemplate } from '$lib/data/courses';
+import type { Season } from '$lib/data/season';
 import { createStudyPlan, normalizePlan, type StudyPlan } from '$lib/data/study-plan';
 
 const KEYS = {
   template: 'currentTemplate',
   plan: 'selectedPlan',
   shortNames: 'showShortNamesOnly',
+  startSeason: 'startSeason',
   legacySelections: 'userSelections',
   planFor: (templateId: string) => `studyPlan:${templateId}`
 } as const;
@@ -74,6 +76,13 @@ export const planPrefs = {
   },
   loadTemplateId: (): string | null => read(KEYS.template),
   loadPlanCode: (): string | null => read(KEYS.plan),
+  saveStartSeason(season: Season): void {
+    write(KEYS.startSeason, season);
+  },
+  loadStartSeason(): Season | null {
+    const raw = read(KEYS.startSeason);
+    return raw === 'HS' || raw === 'FS' ? raw : null;
+  },
   saveShortNames(value: boolean): void {
     write(KEYS.shortNames, JSON.stringify(value));
   },


### PR DESCRIPTION
- Shows which season a course takes place
- if searching for a course in the wrong season its disabled and has a tooltip showing which season its available
- Instead of selecting plan, users now select year and season when they started and the plan is picked automatically
- instead of showing "Semester 1, 2, 3 ..." on the canvas it now shows year and season

Solves #5 

<img width="366" height="112" alt="Screenshot From 2026-06-14 02-27-01" src="https://github.com/user-attachments/assets/94a56b49-51f0-4a12-9125-5145ef7c493b" />
<br/>
<img width="407" height="112" alt="Screenshot From 2026-06-14 02-27-11" src="https://github.com/user-attachments/assets/688cd374-9d88-4528-9ef0-69f4efd76163" />

<img width="441" height="447" alt="Screenshot From 2026-06-14 02-27-28" src="https://github.com/user-attachments/assets/4e368e07-43d6-4e5a-92e3-f279056aca7c" />

<img width="863" height="716" alt="image" src="https://github.com/user-attachments/assets/1e212ecb-b324-4e50-bbff-d84a89644bc5" />
